### PR TITLE
customerData.invalidate(sections) cause JS error

### DIFF
--- a/view/frontend/layout/checkout_cart_index.xml
+++ b/view/frontend/layout/checkout_cart_index.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0"?>
-
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
-    <body>
-        <referenceContainer name="before.body.end">
-            <block name="invalidate_minicart" template="MageSuite_DailyDeal::invalidate_minicart.phtml" after="-" ifconfig="daily_deal/general/active"/>
-        </referenceContainer>
-    </body>
-</page>

--- a/view/frontend/templates/invalidate_minicart.phtml
+++ b/view/frontend/templates/invalidate_minicart.phtml
@@ -1,8 +1,0 @@
-<script>
-    require([
-        'Magento_Customer/js/customer-data'
-    ], function (customerData) {
-        var sections = ['cart'];
-        customerData.invalidate(sections);
-    });
-</script>


### PR DESCRIPTION
customerData.invalidate(sections) in view/frontend/templates/invalidate_minicart.phtml of this module cause JavaScripts errors in checkout/cart (at least at Magento 2.4.x) - when Daily Deals are enabled, then we see a lof of errors in Magento_Customer/js/customer-data.js:
storage.remove(sectionName);    <- storage undefined
storage.set(sectionName, sectionData);     <- Cannot read property 'set' of undefined
Some clients gives us also information that they can't remove products at checkout/card and go to checkout - we have confirmed this (in case when some of products from cart become out of stock)

Disabling this invalidate (described in 94c1674#diff-6d8c1b97696e95ff36d411347a867628b63a20b46f7655f74656adf288246358 as performance fix) solve problems.